### PR TITLE
Fix win async

### DIFF
--- a/components/Minesweeper.tsx
+++ b/components/Minesweeper.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import styles from "../styles/Minesweeper.module.css";
 import Cell from "./Cell";
 import {Index2D, MinesweeperCell} from "../types/types";
@@ -81,8 +81,12 @@ const Minesweeper: React.FC<MinesweeperProps> = ({width, height, bombs}) => {
   };
 
   const updateFlags = (value: boolean) => {
-    setFlags(flags + (value ? 1 : -1), checkWin());
+    setFlags(flags + (value ? 1 : -1));
   };
+
+  useEffect(() => {
+    checkWin();
+  }, [flags]);
 
   const retry = () => {
     setLost(false);

--- a/components/Minesweeper.tsx
+++ b/components/Minesweeper.tsx
@@ -81,8 +81,7 @@ const Minesweeper: React.FC<MinesweeperProps> = ({width, height, bombs}) => {
   };
 
   const updateFlags = (value: boolean) => {
-    setFlags(flags + (value ? 1 : -1));
-    checkWin();
+    setFlags(flags + (value ? 1 : -1), checkWin());
   };
 
   const retry = () => {


### PR DESCRIPTION
Changed calling function after async useState setFlags to useEffect so it would not be a tep behind when trying to check for a win.